### PR TITLE
Configure chart for deprecation.

### DIFF
--- a/prometheus-statsd-exporter/Chart.yaml
+++ b/prometheus-statsd-exporter/Chart.yaml
@@ -1,15 +1,14 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 home: https://github.com/prometheus/statsd_exporter
-description: StatsD to Prometheus metrics exporter.
+description: DEPRECATED - StatsD to Prometheus metrics exporter.
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: 0.16.0
 keywords:
 - statsd
 - prometheus
 - metrics
 - graphite
-maintainers:
-- name: niclic
-  email: git@niclic.com
+# https://github.com/prometheus-community/helm-charts
+deprecated: true

--- a/prometheus-statsd-exporter/README.md
+++ b/prometheus-statsd-exporter/README.md
@@ -1,5 +1,8 @@
 # prometheus-statsd-exporter
 
+## Deprecation Warning
+A new version of this chart is available [here](https://github.com/prometheus-community/helm-charts).
+
 The [prometheus-statsd-exporter](https://github.com/prometheus/statsd_exporter) receives StatsD metrics and exports them as Prometheus metrics.
 
 ## Introduction


### PR DESCRIPTION
Another version of this chart was created [here](https://github.com/prometheus-community/helm-charts/pull/449) before this chart could be [migrated](https://github.com/prometheus-community/helm-charts/pull/372).